### PR TITLE
build(deps): consolidate open Dependabot updates

### DIFF
--- a/model-serving/pyproject.toml
+++ b/model-serving/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.50.0",
     "pydantic>=2.13.0",
-    "torch>=2.12.0",
+    "torch>=2.13.0",
     "numpy>=2.1.0",
     "pyyaml>=6.0.3",
     "python-multipart>=0.0.32",
@@ -70,7 +70,7 @@ dev = [
 ]
 
 gpu = [
-    "torch>=2.12.0",
+    "torch>=2.13.0",
 ]
 
 monitoring = [

--- a/model-serving/pyproject.toml
+++ b/model-serving/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 keywords = [
     "reinforcement-learning",
-    "autonomous-vehicles", 
+    "autonomous-vehicles",
     "carla",
     "model-serving",
     "fastapi",

--- a/model-serving/requirements.txt
+++ b/model-serving/requirements.txt
@@ -12,7 +12,7 @@ jinja2==3.1.6
 watchdog==6.0.0
 deepdiff==9.1.0
 psutil==7.2.2
-torch==2.12.1
+torch==2.13.0
 numpy==2.5.1
 requests==2.34.2
 httpx==0.28.1

--- a/model-serving/uv.lock
+++ b/model-serving/uv.lock
@@ -249,8 +249,8 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.15.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "toml", specifier = ">=0.10.2" },
-    { name = "torch", specifier = ">=2.12.0" },
-    { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.12.0" },
+    { name = "torch", specifier = ">=2.13.0" },
+    { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.13.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.50.0" },
     { name = "watchdog", specifier = ">=4.0.0" },
 ]
@@ -399,42 +399,51 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "13.0.2"
+version = "13.0.3.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -1425,11 +1434,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -1513,16 +1522,15 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -1533,14 +1541,14 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/54/efb7ebca77970012b0cc21687a55d70eb2ba514b2c2b8e18d9fb1222f3be/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d2dd0f2c5f7ccbddaf34cade0deaf476808368f902b9cdb7f36a2ab42301bc0e", size = 87991951, upload-time = "2026-06-17T21:07:49.309Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/00/4210d76ca7424981f04033ebe7e48816ab83287a62538747a58825db770c/torch-2.12.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2de4e19b88a481482c6c75291f2d6a52eda3ce51f311b29aa9b68499c830c07c", size = 426382721, upload-time = "2026-06-17T21:06:41.842Z" },
-    { url = "https://files.pythonhosted.org/packages/76/1f/bc9f5a5aa569307076365f25afcebacb22e9c754b1bcfbaaa146627c7fda/torch-2.12.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:649e4ced014ba646f76f8cb9c9726735a6323eb321b7919f942790a923f90921", size = 532261322, upload-time = "2026-06-17T21:06:06.673Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/49/c549461daa008159d006a76a991fbc2f26fa8bac27a4030c858463dcb20f/torch-2.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:e86550597877fb272ddc52db2f85b82cb601ea7bd932576a0340152cae2200b3", size = 122988095, upload-time = "2026-06-17T21:07:44.9Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/4a/0300261818e1560d72cc160ac826005507e8b7ca0a35788b591436d05b4a/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", size = 87992358, upload-time = "2026-06-17T21:07:40.299Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a7/874a5ca05e8f159211dca7921060f7057acc1adb26431e119fd150623efc/torch-2.12.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fcb61ccd20784b62bdd78ec84238a5cfb383b4994902e03bac95505ab360884c", size = 426386134, upload-time = "2026-06-17T21:07:31.481Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/75/20bb8fe9c1ad6538cce8cd0391b51927ae5af0b17ed1eab44b8824465dc1/torch-2.12.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f4afc8083dff08719edbea346644476e3cec0cf40ebe256be0ee5d5b7c7e8c0d", size = 532268019, upload-time = "2026-06-17T21:05:37.925Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/fa/824ddb662af55b2eabc0dbb7b57c7c0b1bcd93693754a2b8509ec4d16490/torch-2.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:f92609e3b3ce72f25e2eb780d043ced2480c1a86c47c852604fc7a9108648386", size = 122987777, upload-time = "2026-06-17T21:07:09.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
 ]
 
 [[package]]

--- a/model-sim/uv.lock
+++ b/model-sim/uv.lock
@@ -330,14 +330,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Intent

Turn the prepared Dependabot consolidation into one final reviewable PR. Confirm and include the six open Dependabot updates from PRs #39, #40, #41, #49, #51, and #52 while limiting the committed diff exactly to model-serving/pyproject.toml, model-serving/requirements.txt, model-serving/uv.lock, and model-sim/uv.lock. Validate the uv locks and dependency imports, push branch deps/consolidated-dependabot-updates, and create a PR titled 'build(deps): consolidate open Dependabot updates' whose body explicitly states that it supersedes all six PRs.

## What Changed

- Raise model-serving’s Torch requirement and pin to 2.13.0, with refreshed lock entries for Torch, Setuptools 83.0.0, and CUDA Toolkit 13.0.3.0.
- Refresh the model-sim lockfile to GitPython 3.1.57.
- This PR supersedes Dependabot PRs #39, #40, #41, #49, #51, and #52.

## Risk Assessment

✅ Low: The dependency-only change is well-bounded, includes the six requested updates or newer resolved versions, and modifies exactly the four authorized files with no material source risks found.

## Testing

Baseline scope and source-PR inspection, both uv lock checks, frozen installs, focused automated tests, and manual runtime probes succeeded after correcting a pytest invocation-path setup issue. Evidence demonstrates the four-file scope, all six dependency outcomes, successful affected imports, Torch-backed inference, HTTP 200 health behavior, GitPython repository access, IDNA encoding, and a real highway simulation step. This dependency-only change has no UI surface, so screenshot evidence was not applicable. Push and PR creation were not performed because the outer executor owns those later phases.

<details>
<summary>Evidence: Exact diff scope and six Dependabot resolutions</summary>

```text
{
  "result": "PASS",
  "target_commit": "2cb55acb1703fc9088ff9e90550bb6469d7249be",
  "committed_diff": [
    "model-serving/pyproject.toml",
    "model-serving/requirements.txt",
    "model-serving/uv.lock",
    "model-sim/uv.lock"
  ],
  "dependabot_updates_satisfied": {
    "#39 idna 3.13 -> 3.15 (model-serving)": "resolved 3.18",
    "#40 idna 3.13 -> 3.15 (model-sim)": "resolved 3.18",
    "#41 idna 3.13 -> 3.15": "resolved 3.18",
    "#49 torch 2.12.1 -> 2.13.0": "resolved 2.13.0",
    "#51 gitpython 3.1.50 -> 3.1.54": "resolved 3.1.57",
    "#52 setuptools 81.0.0 -> 83.0.0": "resolved 83.0.0"
  },
  "lock_consistency": {
    "model-serving": "uv lock --check passed",
    "model-sim": "uv lock --check passed"
  }
}
```
</details>
<details>
<summary>Evidence: Model-serving imports, Torch inference, and health endpoint</summary>

```text
{
  "result": "PASS",
  "frozen_environment": "model-serving/uv.lock",
  "successful_imports": [
    "torch",
    "setuptools",
    "idna"
  ],
  "installed_versions": {
    "torch": "2.13.0",
    "setuptools": "83.0.0",
    "idna": "3.18"
  },
  "torch_policy_forward": {
    "input": [
      [
        4.0,
        5.0
      ]
    ],
    "weights": [
      [
        2.0,
        3.0
      ]
    ],
    "output": [
      [
        23.0
      ]
    ]
  },
  "idna_encode": "xn--bcher-kva.example",
  "healthz": {
    "http_status": 200,
    "body": {
      "status": "ok",
      "version": "v0.1.0",
      "git": "2cb55ac",
      "device": "cpu",
      "timestamp": 1785316516.3410509
    }
  }
}
```
</details>
<details>
<summary>Evidence: Model-sim imports, repository access, and simulation step</summary>

```text
{
  "result": "PASS",
  "frozen_environment": "model-sim/uv.lock",
  "installed_versions": {
    "gitpython": "3.1.57",
    "idna": "3.18",
    "wandb": "0.28.0",
    "highway-env": "1.11"
  },
  "gitpython_repository_probe": {
    "commit": "2cb55acb1703fc9088ff9e90550bb6469d7249be",
    "worktree": "/Users/taylor/.no-mistakes/worktrees/6c616e979ff3/01KYPHSQ9BJ2T0145R1JE9R3VF"
  },
  "idna_encode": "xn--bcher-kva.example",
  "highway_simulation_step": {
    "environment": "highway-v0",
    "seed": 7,
    "observation_shape": [
      5,
      5
    ],
    "sampled_action": 1,
    "reward": 0.8666666666666667,
    "terminated": false,
    "truncated": false,
    "next_observation_shape": [
      5,
      5
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status 984ce7d61bb1a4e15721e4525798e5fa1736e356..2cb55acb1703fc9088ff9e90550bb6469d7249be` and corresponding stat/unified-diff inspection</code>
- <code>Read-only `/opt/homebrew/bin/gh-axi pr view` and `pr diff` checks for PRs #39, #40, #41, #49, #51, and #52</code>
- <code>`git ls-remote --heads origin deps/consolidated-dependabot-updates` and `/opt/homebrew/bin/gh-axi pr list --head deps/consolidated-dependabot-updates` (read-only publication check)</code>
- `uv lock --check --project model-serving`
- `uv lock --check --project model-sim`
- `uv sync --project model-serving --frozen --no-dev --no-install-project`
- `uv sync --project model-sim --frozen --no-dev --no-install-project`
- <code>Initial direct pytest entrypoint attempts encountered a setup-only `src` import-path error; retried successfully using `python -m pytest`</code>
- `cd model-serving && ./.venv/bin/python -m pytest -o addopts='' tests/test_model_loader.py::TestPolicyWrapper tests/test_api_endpoints.py::TestHealthEndpoint::test_health_check_success -q`
- `model-sim/.venv/bin/python model-sim/tests/test_cross_platform.py TestCrossPlatformCompatibility.test_basic_dependencies`
- `TOML acceptance probe verifying the exact four-file diff and resolved Torch, Setuptools, GitPython, and IDNA versions`
- <code>Frozen model-serving runtime probe importing Torch, Setuptools, and IDNA, performing a project policy forward pass, and requesting `/healthz`</code>
- <code>Frozen model-sim runtime probe importing GitPython and IDNA, reading the target repository, and resetting/stepping `highway-v0`</code>
- <code>Post-test `git status --short`, transient-artifact scan, and `python3 -m json.tool` validation of all evidence files</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 2 warnings</summary>

- ⚠️ `.pre-commit-config.yaml:40` - Pre-commit cannot initialize the mypy environment because `types-all` requires unavailable `types-pkg-resources`; repairing this pre-existing hook is outside the required four-file diff.
- ⚠️ `.pre-commit-config.yaml:54` - The configured detect-secrets hook references missing `.secrets.baseline` and therefore cannot run normally. A direct scan of all changed files passed; repairing the hook is outside the required four-file diff.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
